### PR TITLE
Support rendering of various circle emojis for Docusaurus markdown flavor

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,12 +47,18 @@ const main = async () => {
   }
   const findAll = findAllLinksInput === "true";
 
-  const updatedContent = await findAndPlaceBadges(
+  let updatedContent = await findAndPlaceBadges(
     octokit,
     content,
     config,
     findAll
   );
+  
+  // Work around for limited rendering support in various markdown flavors
+  updatedContent = updatedContent.replace(/:green_circle:/g, '🟢');
+  updatedContent = updatedContent.replace(/:yellow_circle:/g, '🟡');
+  updatedContent = updatedContent.replace(/:red_circle:/g, '🔴');
+  updatedContent = updatedContent.replace(/:grey_question:/g, '❔');
 
   const doPullRequest = core.getInput("pull-request") === "true";
 

--- a/index.js
+++ b/index.js
@@ -47,18 +47,12 @@ const main = async () => {
   }
   const findAll = findAllLinksInput === "true";
 
-  let updatedContent = await findAndPlaceBadges(
+  const updatedContent = await findAndPlaceBadges(
     octokit,
     content,
     config,
     findAll
   );
-  
-  // Work around for limited rendering support in various markdown flavors
-  updatedContent = updatedContent.replace(/:green_circle:/g, '🟢');
-  updatedContent = updatedContent.replace(/:yellow_circle:/g, '🟡');
-  updatedContent = updatedContent.replace(/:red_circle:/g, '🔴');
-  updatedContent = updatedContent.replace(/:grey_question:/g, '❔');
 
   const doPullRequest = core.getInput("pull-request") === "true";
 

--- a/modules/mod.js
+++ b/modules/mod.js
@@ -117,7 +117,7 @@ export async function findAndPlaceBadges(
     regex = badgeRegex;
   }
 
-  const updatedContent = await replaceAsync(
+  let updatedContent = await replaceAsync(
     text,
     regex,
     async (match, baseUrl, owner, repo, tail, _emoji, badge) => {
@@ -162,6 +162,12 @@ export async function findAndPlaceBadges(
       return `${baseUrl}${tail ? tail : ""} ${emoji}`;
     }
   );
+
+  // Work around for limited rendering support in various markdown flavors
+  //updatedContent = updatedContent.replace(/:green_circle:/g, '🟢');
+  updatedContent = updatedContent.replace(/:yellow_circle:/g, '🟡');
+  updatedContent = updatedContent.replace(/:red_circle:/g, '🔴');
+  updatedContent = updatedContent.replace(/:grey_question:/g, '❔');
 
   return updatedContent;
 }

--- a/modules/mod.js
+++ b/modules/mod.js
@@ -164,7 +164,7 @@ export async function findAndPlaceBadges(
   );
 
   // Work around for limited rendering support in various markdown flavors
-  //updatedContent = updatedContent.replace(/:green_circle:/g, '🟢');
+  updatedContent = updatedContent.replace(/:green_circle:/g, '🟢');
   updatedContent = updatedContent.replace(/:yellow_circle:/g, '🟡');
   updatedContent = updatedContent.replace(/:red_circle:/g, '🔴');
   updatedContent = updatedContent.replace(/:grey_question:/g, '❔');


### PR DESCRIPTION
This is a work around to address https://github.com/w3f/polkadot-wiki/issues/3674 and supplemental to https://github.com/w3f/polkadot-wiki/pull/3685.

My knowledge of the regex pattern used to update the badges is limited so @lucasvanmol feel free to suggest a better solution for integrating this change.  This solution keeps the original logic but replaces the results with the formatting used in [#3600](https://github.com/w3f/polkadot-wiki/pull/3660/files) by @DrW3RK to render the circles instead of hearts.  If the default emojis are not used, the replacement functions shouldn't modify the results.